### PR TITLE
Readme fix, shows English instead of French and Paystation instead of Cr...

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,16 +49,19 @@ $user->setEmail('example@example.com')
 $invoice = new Invoice;
 $invoice->setVirtualCurrencyAmount(5);
 
-$url = $urlBuilderFactory->getCreditCards()
+$url = $urlBuilderFactory->getPayStation()
     ->setInvoice($invoice)
     ->setUser($user)
     ->unlockParameterForUser('email')
     ->setCountry('US')
-    ->setLocale('fr')
+    ->setLocale('en')
+    ->setParameter('theme', 115)
     ->setParameter('description', 'Purchase description')
     ->getUrl();
 
 echo $url.PHP_EOL;
+
+?>
 ```
 ### Receive [Instant Payment Notification](http://xsolla.github.io/en/currency.html)
 


### PR DESCRIPTION
SDK shows Paydesk with French.  We've decided that for new users, it's best to have this in English, and show Paystation.
