### PR TITLE
[BC BREAK] `XsollaClient::UpdateVirtualItemOrderInGroup` HTTP method …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
-## [Unreleased](https://github.com/xsolla/xsolla-sdk-php/compare/v2.0.0...master)
+## [Unreleased](https://github.com/xsolla/xsolla-sdk-php/compare/v2.0.1...master)
+
+## [v2.0.1](https://github.com/xsolla/xsolla-sdk-php/compare/v2.0.0...v2.0.1)
+### Fixed
+* [BC BREAK] `XsollaClient::UpdateVirtualItemOrderInGroup` HTTP method changed from PUT to POST
 
 ## [v2.0.0](https://github.com/xsolla/xsolla-sdk-php/compare/v2.0.0-BETA1...v2.0.0)
 ### Added

--- a/src/API/Resources/xsolla-2015-07-23.php
+++ b/src/API/Resources/xsolla-2015-07-23.php
@@ -717,7 +717,7 @@ return array(
             ),
         ),
         'UpdateVirtualItemOrderInGroup' => array(
-            'httpMethod' => 'PUT',
+            'httpMethod' => 'POST',
             'uri' => 'https://api.xsolla.com/merchant/projects/{project_id}/virtual_items/sort',
             'summary' => 'Update items order in group',
             'parameters' => array(

--- a/src/Version.php
+++ b/src/Version.php
@@ -4,7 +4,7 @@ namespace Xsolla\SDK;
 
 class Version
 {
-    const VERSION = 'v2.0.0';
+    const VERSION = 'v2.0.1';
 
     /**
      * @return string


### PR DESCRIPTION
…changed from PUT to POST. 2.0.1 version bumped