### PR TITLE
Added setUserAttributes function to TokenRequest class

### DIFF
--- a/src/API/PaymentUI/TokenRequest.php
+++ b/src/API/PaymentUI/TokenRequest.php
@@ -109,6 +109,18 @@ class TokenRequest
     }
 
     /**
+     * @param array $userAttributes
+     *
+     * @return self
+     */
+    public function setUserAttributes(array $userAttributes)
+    {
+        $this->data['user']['attributes'] = $userAttributes;
+
+        return $this;
+    }
+
+    /**
      * @return array
      */
     public function toArray()


### PR DESCRIPTION
While trying to trigger promotions based on user attributes, I found that it wasn't easily possible to pass user attributes using the TokenRequest class.
So instead of doing the REST call manually, I simply added the "setUserAttributes" function to the TokenRequest class.