### PR TITLE
Allow all php 7.4 versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 ## [Unreleased](https://github.com/xsolla/xsolla-sdk-php/compare/v4.1.1...master)
+* Changed support version of PHP from 7.1.3 to 7.4.x
 
 ## [v4.1.1](https://github.com/xsolla/xsolla-sdk-php/compare/v4.1.0...v4.1.1) - 2020-07-16
 ### Added

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ An official PHP SDK for interacting with [Xsolla API](https://developers.xsolla.
 
 ## Requirements
 
-* PHP >=7.1.3 <= 7.4.5
+* PHP >=7.1.3 <7.5.0
 * The following PHP extensions are required:
   * curl
   * json

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
       "source": "https://github.com/xsolla/xsolla-sdk-php/releases"
     },
     "require": {
-        "php": ">=7.1.3 <=7.4.5",
+        "php": ">=7.1.3 <7.5.0",
         "ext-curl": "*",
         "ext-json": "*",
         "guzzlehttp/guzzle": "~6.0",


### PR DESCRIPTION
Limiting only up to 7.4.5 practically means 7.4.x isn't supported because one shouldn't use 7.4.5 anymore as there are security fixes on later versions.

If the intention is only to support tested versions, then it's missing constraint for earlier php versions; neither of 7.2.x or 7.3.x have patch version constraint. Why only php 7.4?