### PR TITLE
Bump php support version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build/artifacts
 phpunit.xml
 composer.lock
 .php_cs.cache
+.phpunit.result.cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 ## [Unreleased](https://github.com/xsolla/xsolla-sdk-php/compare/v4.1.2...master)
+* Changed support version of PHP to ^7.1.3|^8.0
+* Changed version of phpunit/phpunit from ~7.3 to ^9.0
+* Fixed null-return in AfsRejectMessage::getExternalPaymentId() (Missing 'return' statement)
+* Fixed process creation in ServerTest::setUpPhpServer() (expected parameter of type 'array')
+* Fixed "Qualifier can be replaced with an import"
+* Fixed "Redundant default attribute value assignment" in phpunit.xml.dist
 
 ## [v4.1.2](https://github.com/xsolla/xsolla-sdk-php/compare/v4.1.1...v4.1.2) - 2020-10-09
 ### Added

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ An official PHP SDK for interacting with [Xsolla API](https://developers.xsolla.
 
 ## Requirements
 
-* PHP >=7.1.3 <7.5.0
+* PHP ^7.1.3 or ^8.0
 * The following PHP extensions are required:
   * curl
   * json

--- a/composer.json
+++ b/composer.json
@@ -3,23 +3,23 @@
     "type": "library",
     "description":"Xsolla SDK for PHP. Xsolla is the authorized reseller and merchant providing e-commerce services for online games.",
     "keywords": ["sdk", "xsolla", "api", "payment", "games"],
-    "homepage": "http://xsolla.com",
+    "homepage": "https://xsolla.com",
     "license": "MIT",
     "support": {
       "email": "integration@xsolla.com",
       "issues": "https://github.com/xsolla/xsolla-sdk-php/issues",
-      "docs": "http://developers.xsolla.com",
+      "docs": "https://developers.xsolla.com",
       "source": "https://github.com/xsolla/xsolla-sdk-php/releases"
     },
     "require": {
-        "php": ">=7.1.3 <7.5.0",
+        "php": "^7.1.3|^8.0",
         "ext-curl": "*",
         "ext-json": "*",
         "guzzlehttp/guzzle": "~6.0",
         "symfony/http-foundation": "~2.3 || ~3.0 || ~4.0 || ~5.0"
     },
     "require-dev": {
-      "phpunit/phpunit": "~7.3",
+      "phpunit/phpunit": "^9.0",
       "symfony/process": "~4.1",
       "friendsofphp/php-cs-fixer": "~2.13",
       "mtdowling/burgomaster": "^0.0.3"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,44 +1,30 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/7.3/phpunit.xsd"
-
-        backupGlobals               = "false"
-        backupStaticAttributes      = "false"
-        colors                      = "true"
-        convertErrorsToExceptions   = "true"
-        convertNoticesToExceptions  = "true"
-        convertWarningsToExceptions = "true"
-        processIsolation            = "false"
-        stopOnFailure               = "false"
-        bootstrap                   = "./vendor/autoload.php"
-        >
-
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" colors="true"
+         bootstrap="./vendor/autoload.php">
+    <coverage>
+        <include>
+            <directory>./src/</directory>
+        </include>
+    </coverage>
     <php>
-        <ini name="error_reporting" value="-1" />
-        <ini name="display_errors" value="On" />
-        <ini name="display_startup_errors" value="On" />
-        <env name="COUPON_CODE" value="1wpb1igjBig0g" />
-        <env name="CAMPAIGN_ID" value="2378" />
-        <env name="GAME_DELIVERY_ENTITY_ID" value="24" />
-        <env name="USER_ID" value="1" />
+        <ini name="error_reporting" value="-1"/>
+        <ini name="display_errors" value="On"/>
+        <ini name="display_startup_errors" value="On"/>
+        <env name="COUPON_CODE" value="1wpb1igjBig0g"/>
+        <env name="CAMPAIGN_ID" value="2378"/>
+        <env name="GAME_DELIVERY_ENTITY_ID" value="24"/>
+        <env name="USER_ID" value="1"/>
         <!--
         <env name="MERCHANT_ID" value="1" />
         <env name="PROJECT_ID" value="1" />
         <env name="API_KEY" value="secret" />
         -->
     </php>
-
     <testsuites>
         <testsuite name="Xsolla SDK for PHP Test Suite">
             <directory>./tests/Unit</directory>
             <directory>./tests/Integration</directory>
         </testsuite>
     </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory>./src/</directory>
-        </whitelist>
-    </filter>
 </phpunit>

--- a/src/API/PaymentUI/TokenRequest.php
+++ b/src/API/PaymentUI/TokenRequest.php
@@ -56,8 +56,6 @@ class TokenRequest
     }
 
     /**
-     * @param array $customParameters
-     *
      * @return self
      */
     public function setCustomParameters(array $customParameters)
@@ -110,8 +108,6 @@ class TokenRequest
     }
 
     /**
-     * @param array $userAttributes
-     *
      * @return self
      */
     public function setUserAttributes(array $userAttributes)

--- a/src/API/XsollaClient.php
+++ b/src/API/XsollaClient.php
@@ -2,10 +2,12 @@
 
 namespace Xsolla\SDK\API;
 
+use Exception;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\BadResponseException;
 use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Exception\GuzzleException;
+use InvalidArgumentException;
 use Xsolla\SDK\API\PaymentUI\TokenRequest;
 use Xsolla\SDK\Exception\API\XsollaAPIException;
 use Xsolla\SDK\Version;
@@ -142,7 +144,7 @@ class XsollaClient extends Client
         $config += ['ssl.certificate_authority' => 'system'];
 
         if ($missing = array_diff($required, array_keys($config))) {
-            throw new \InvalidArgumentException('Config is missing the following keys: '.implode(', ', $missing));
+            throw new InvalidArgumentException('Config is missing the following keys: '.implode(', ', $missing));
         }
 
         $config['auth'] = [$config['merchant_id'], $config['api_key'], 'Basic'];
@@ -186,7 +188,7 @@ class XsollaClient extends Client
             $response = $this->request($operation['httpMethod'], $uri, $requestParams);
         } catch (BadResponseException | ClientException $exception) {
             throw XsollaAPIException::fromBadResponse($exception);
-        } catch (\Exception | GuzzleException $exception) {
+        } catch (Exception | GuzzleException $exception) {
             throw new XsollaAPIException('XsollaClient Exception: '.$exception->getMessage().' Please check troubleshooting section in README.md https://github.com/xsolla/xsolla-sdk-php#troubleshooting', 0, $exception);
         }
 
@@ -208,7 +210,6 @@ class XsollaClient extends Client
     }
 
     /**
-     * @param  TokenRequest $tokenRequest
      * @return string
      */
     public function createPaymentUITokenFromRequest(TokenRequest $tokenRequest)

--- a/src/Exception/API/XsollaAPIException.php
+++ b/src/Exception/API/XsollaAPIException.php
@@ -4,6 +4,7 @@ namespace Xsolla\SDK\Exception\API;
 
 use GuzzleHttp\Exception\BadResponseException;
 use Xsolla\SDK\Exception\XsollaException;
+use function GuzzleHttp\Psr7\str;
 
 class XsollaAPIException extends XsollaException
 {
@@ -30,7 +31,6 @@ Response:
 EOF;
 
     /**
-     * @param  BadResponseException $previous
      * @return XsollaAPIException
      */
     public static function fromBadResponse(BadResponseException $previous)
@@ -39,8 +39,8 @@ EOF;
         $message = sprintf(
             static::$messageTemplate,
             $previous->getMessage(),
-            \GuzzleHttp\Psr7\str($previous->getRequest()),
-            \GuzzleHttp\Psr7\str($previous->getResponse())
+            str($previous->getRequest()),
+            str($previous->getResponse())
         );
         if (array_key_exists($statusCode, static::$exceptions)) {
             return new static::$exceptions[$statusCode]($message, 0, $previous);

--- a/src/Webhook/Message/AfsRejectMessage.php
+++ b/src/Webhook/Message/AfsRejectMessage.php
@@ -4,7 +4,6 @@ namespace Xsolla\SDK\Webhook\Message;
 
 class AfsRejectMessage extends Message
 {
-
     /**
      * @return array
      */
@@ -29,6 +28,8 @@ class AfsRejectMessage extends Message
         if (array_key_exists('external_id', $this->request['transaction'])) {
             return $this->request['transaction']['external_id'];
         }
+
+        return null;
     }
 
     /**
@@ -46,5 +47,4 @@ class AfsRejectMessage extends Message
     {
         return $this->request['refund_details'];
     }
-
 }

--- a/src/Webhook/Message/Message.php
+++ b/src/Webhook/Message/Message.php
@@ -27,7 +27,7 @@ abstract class Message
         self::UPDATE_SUBSCRIPTION => '\Xsolla\SDK\Webhook\Message\UpdateSubscriptionMessage',
         self::USER_BALANCE => '\Xsolla\SDK\Webhook\Message\UserBalanceMessage',
         self::GET_PIN_CODE => '\Xsolla\SDK\Webhook\Message\GetPinCodeMessage',
-        self::AFS_REJECT => '\Xsolla\SDK\Webhook\Message\AfsRejectMessage'
+        self::AFS_REJECT => '\Xsolla\SDK\Webhook\Message\AfsRejectMessage',
     ];
 
     /**
@@ -36,8 +36,6 @@ abstract class Message
     protected $request;
 
     /**
-     * @param array $request
-     *
      * @throws InvalidParameterException
      * @return Message
      */
@@ -55,9 +53,6 @@ abstract class Message
         return new $className($request);
     }
 
-    /**
-     * @param array $request
-     */
     public function __construct(array $request)
     {
         $this->request = $request;

--- a/src/Webhook/Response/UserResponse.php
+++ b/src/Webhook/Response/UserResponse.php
@@ -7,9 +7,6 @@ use Xsolla\SDK\Webhook\WebhookResponse;
 
 class UserResponse extends WebhookResponse
 {
-    /**
-     * @param User $user
-     */
     public function __construct(User $user)
     {
         $this->validateStringParameter('User id', $user->getId());

--- a/src/Webhook/WebhookAuthenticator.php
+++ b/src/Webhook/WebhookAuthenticator.php
@@ -29,8 +29,7 @@ class WebhookAuthenticator
     }
 
     /**
-     * @param WebhookRequest $webhookRequest
-     * @param bool           $checkClientIp
+     * @param bool $checkClientIp
      *
      * @throws InvalidClientIpException
      * @throws InvalidSignatureException
@@ -51,17 +50,11 @@ class WebhookAuthenticator
     public function authenticateClientIp($clientIp)
     {
         if (false === IpUtils::checkIp($clientIp, self::$xsollaSubnets)) {
-            throw new InvalidClientIpException(sprintf(
-                'Client IP address (%s) not found in allowed IP addresses whitelist (%s). Please check troubleshooting section in README.md https://github.com/xsolla/xsolla-sdk-php#troubleshooting',
-                $clientIp,
-                implode(', ', self::$xsollaSubnets)
-            ));
+            throw new InvalidClientIpException(sprintf('Client IP address (%s) not found in allowed IP addresses whitelist (%s). Please check troubleshooting section in README.md https://github.com/xsolla/xsolla-sdk-php#troubleshooting', $clientIp, implode(', ', self::$xsollaSubnets)));
         }
     }
 
     /**
-     * @param WebhookRequest $webhookRequest
-     *
      * @throws InvalidSignatureException
      */
     public function authenticateSignature(WebhookRequest $webhookRequest)

--- a/src/Webhook/WebhookRequest.php
+++ b/src/Webhook/WebhookRequest.php
@@ -48,7 +48,6 @@ class WebhookRequest
     }
 
     /**
-     * @param array  $headers
      * @param string $body
      * @param string $clientIp
      */

--- a/src/Webhook/WebhookResponse.php
+++ b/src/Webhook/WebhookResponse.php
@@ -2,6 +2,7 @@
 
 namespace Xsolla\SDK\Webhook;
 
+use Exception;
 use Symfony\Component\HttpFoundation\Response;
 use Xsolla\SDK\API\XsollaClient;
 use Xsolla\SDK\Exception\Webhook\XsollaWebhookException;
@@ -25,11 +26,9 @@ class WebhookResponse
     protected $symfonyResponse;
 
     /**
-     * @param \Exception $e
-     *
      * @return WebhookResponse
      */
-    public static function fromException(\Exception $e)
+    public static function fromException(Exception $e)
     {
         if ($e instanceof XsollaWebhookException) {
             return static::fromErrorCode($e->getXsollaErrorCode(), $e->getMessage(), $e->getHttpStatusCode());
@@ -85,11 +84,7 @@ class WebhookResponse
     protected function validateStringParameter($name, $value)
     {
         if (!is_string($value)) {
-            throw new XsollaWebhookException(sprintf(
-                '%s should be non-empty string. %s given',
-                $name,
-                is_object($value) ? get_class($value) : gettype($value)
-            ));
+            throw new XsollaWebhookException(sprintf('%s should be non-empty string. %s given', $name, is_object($value) ? get_class($value) : gettype($value)));
         }
         if ('' === $value) {
             throw new XsollaWebhookException($name.' should be non-empty string. Empty string given');

--- a/src/Webhook/WebhookServer.php
+++ b/src/Webhook/WebhookServer.php
@@ -2,6 +2,7 @@
 
 namespace Xsolla\SDK\Webhook;
 
+use Exception;
 use Symfony\Component\HttpFoundation\Response;
 use Xsolla\SDK\Exception\Webhook\XsollaWebhookException;
 use Xsolla\SDK\Webhook\Message\Message;
@@ -30,8 +31,7 @@ class WebhookServer
     }
 
     /**
-     * @param callable             $webhookCallback
-     * @param WebhookAuthenticator $webhookAuthenticator
+     * @param callable $webhookCallback
      *
      * @throws XsollaWebhookException
      */
@@ -74,7 +74,7 @@ class WebhookServer
             }
 
             return $webhookResponse->getSymfonyResponse();
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             return WebhookResponse::fromException($e)->getSymfonyResponse();
         }
     }

--- a/tests/Integration/API/AbstractAPITest.php
+++ b/tests/Integration/API/AbstractAPITest.php
@@ -28,7 +28,7 @@ abstract class AbstractAPITest extends TestCase
      */
     protected static $userId;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         static::$projectId = (int) getenv('PROJECT_ID');
         static::$merchantId = (int) getenv('MERCHANT_ID');

--- a/tests/Integration/API/CouponsTest.php
+++ b/tests/Integration/API/CouponsTest.php
@@ -37,7 +37,7 @@ class CouponsTest extends AbstractAPITest
             'project_id' => static::$projectId,
             'code' => getenv('COUPON_CODE'),
         ]);
-        static::assertInternalType('array', $actualCouponData);
+        static::assertIsArray($actualCouponData);
     }
 
     public function testRedeemCoupon()
@@ -49,6 +49,6 @@ class CouponsTest extends AbstractAPITest
                 'user_id' => static::$userId,
             ],
         ]);
-        static::assertInternalType('array', $actualCouponData);
+        static::assertIsArray($actualCouponData);
     }
 }

--- a/tests/Integration/API/CreatePaymentUITokenTest.php
+++ b/tests/Integration/API/CreatePaymentUITokenTest.php
@@ -12,7 +12,7 @@ class CreatePaymentUITokenTest extends AbstractAPITest
     public function testCreateCommonPaymentUIToken()
     {
         $token = static::$xsollaClient->createCommonPaymentUIToken(static::$projectId, static::$userId, true);
-        static::assertInternalType('string', $token);
+        static::assertIsString($token);
     }
 
     public function testCreatePaymentUITokenFromRequest()
@@ -25,7 +25,7 @@ class CreatePaymentUITokenTest extends AbstractAPITest
             ->setUserName('USER_NAME')
             ->setPurchase(1.5, 'EUR');
         $token = static::$xsollaClient->createPaymentUITokenFromRequest($tokenRequest);
-        static::assertInternalType('string', $token);
+        static::assertIsString($token);
     }
 
     public function testCreatePaymentUIToken()
@@ -40,6 +40,6 @@ class CreatePaymentUITokenTest extends AbstractAPITest
         $request['user']['id']['value'] = static::$userId;
         $tokenResponse = static::$xsollaClient->CreatePaymentUIToken(['request' => $request]);
         static::assertArrayHasKey('token', $tokenResponse);
-        static::assertInternalType('string', $tokenResponse['token']);
+        static::assertIsString($tokenResponse['token']);
     }
 }

--- a/tests/Integration/API/EventsTest.php
+++ b/tests/Integration/API/EventsTest.php
@@ -13,6 +13,6 @@ class EventsTest extends AbstractAPITest
             'limit' => 1,
             'offset' => 0,
         ]);
-        static::assertInternalType('array', $events);
+        static::assertIsArray($events);
     }
 }

--- a/tests/Integration/API/GameDeliveryTest.php
+++ b/tests/Integration/API/GameDeliveryTest.php
@@ -49,7 +49,7 @@ class GameDeliveryTest extends AbstractAPITest
         ],
     ];
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
         static::$gameDeliveryEntityId = (int) getenv('GAME_DELIVERY_ENTITY_ID');
@@ -72,7 +72,7 @@ class GameDeliveryTest extends AbstractAPITest
         $response = static::$xsollaClient->ListGameDeliveryEntities([
             'project_id' => static::$projectId,
         ]);
-        static::assertInternalType('array', $response);
+        static::assertIsArray($response);
         static::assertArrayHasKey('id', current($response));
     }
 

--- a/tests/Integration/API/PaymentAccountsTest.php
+++ b/tests/Integration/API/PaymentAccountsTest.php
@@ -13,7 +13,7 @@ class PaymentAccountsTest extends AbstractAPITest
             'project_id' => static::$projectId,
             'user_id' => static::$userId,
         ]);
-        static::assertInternalType('array', $response);
+        static::assertIsArray($response);
     }
 
     public function testChargePaymentAccount()

--- a/tests/Integration/API/ProjectSettingsTest.php
+++ b/tests/Integration/API/ProjectSettingsTest.php
@@ -65,7 +65,7 @@ class ProjectSettingsTest extends AbstractAPITest
                 'project_id' => static::$projectId,
             ]
         );
-        static::assertInternalType('array', $response);
+        static::assertIsArray($response);
     }
 
     public function testUpdateProject()
@@ -82,6 +82,6 @@ class ProjectSettingsTest extends AbstractAPITest
     public function testListProjects()
     {
         $response = static::$xsollaClient->ListProjects();
-        static::assertInternalType('array', $response);
+        static::assertIsArray($response);
     }
 }

--- a/tests/Integration/API/PromotionsTest.php
+++ b/tests/Integration/API/PromotionsTest.php
@@ -2,6 +2,9 @@
 
 namespace Xsolla\SDK\Tests\Integration\API;
 
+use DateTime;
+use DateTimeZone;
+
 /**
  * @group api
  */
@@ -12,7 +15,7 @@ class PromotionsTest extends AbstractAPITest
 
     protected $promotion;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->promotion = [
@@ -30,7 +33,7 @@ class PromotionsTest extends AbstractAPITest
     public function testListPromotions()
     {
         $response = static::$xsollaClient->ListPromotions();
-        static::assertInternalType('array', $response);
+        static::assertIsArray($response);
     }
 
     public function testCreatePromotion()
@@ -50,7 +53,7 @@ class PromotionsTest extends AbstractAPITest
         $response = static::$xsollaClient->GetPromotion([
             'promotion_id' => static::$promotionId,
         ]);
-        static::assertInternalType('array', $response);
+        static::assertIsArray($response);
     }
 
     /**
@@ -89,7 +92,7 @@ class PromotionsTest extends AbstractAPITest
         $response = static::$xsollaClient->GetPromotionSubject([
             'promotion_id' => static::$promotionId,
         ]);
-        static::assertInternalType('array', $response);
+        static::assertIsArray($response);
     }
 
     public function testSetPromotionPaymentSystems()
@@ -105,7 +108,7 @@ class PromotionsTest extends AbstractAPITest
         $response = static::$xsollaClient->GetPromotionPaymentSystems([
             'promotion_id' => static::$promotionId,
         ]);
-        static::assertInternalType('array', $response);
+        static::assertIsArray($response);
     }
 
     /**
@@ -114,14 +117,14 @@ class PromotionsTest extends AbstractAPITest
     public function testSetPromotionPeriods()
     {
         $randomFutureTimestamp = mt_rand(time() + 60, 2147483647);
-        $datetimeStart = \DateTime::createFromFormat('U', $randomFutureTimestamp, new \DateTimeZone('UTC'));
+        $datetimeStart = DateTime::createFromFormat('U', $randomFutureTimestamp, new DateTimeZone('UTC'));
         static::$xsollaClient->SetPromotionPeriods([
             'promotion_id' => static::$promotionId,
             'request' => [
                 'periods' => [
                     [
-                        'from' => $datetimeStart->format(\DateTime::ISO8601),
-                        'to' => $datetimeStart->modify('+ 1 second')->format(\DateTime::ISO8601),
+                        'from' => $datetimeStart->format(DateTime::ISO8601),
+                        'to' => $datetimeStart->modify('+ 1 second')->format(DateTime::ISO8601),
                     ],
                 ],
             ],
@@ -137,7 +140,7 @@ class PromotionsTest extends AbstractAPITest
         $response = static::$xsollaClient->GetPromotionPeriods([
             'promotion_id' => static::$promotionId,
         ]);
-        static::assertInternalType('array', $response);
+        static::assertIsArray($response);
     }
 
     /**
@@ -164,7 +167,7 @@ class PromotionsTest extends AbstractAPITest
         $response = static::$xsollaClient->GetPromotionRewards([
             'promotion_id' => static::$promotionId,
         ]);
-        static::assertInternalType('array', $response);
+        static::assertIsArray($response);
     }
 
     /**
@@ -175,7 +178,7 @@ class PromotionsTest extends AbstractAPITest
         $response = static::$xsollaClient->ReviewPromotion([
             'promotion_id' => static::$promotionId,
         ]);
-        static::assertInternalType('array', $response);
+        static::assertIsArray($response);
     }
 
     /**
@@ -190,10 +193,10 @@ class PromotionsTest extends AbstractAPITest
                 'campaign_names' => ['en' => 'xsolla_api_test_campaign_code'],
                 'redeems_count_for_user' => 1,
                 'campaign_redeems_count_for_user' => 1,
-                'expiration_date' => (new \DateTime('+3day'))->format(DATE_RFC3339),
+                'expiration_date' => (new DateTime('+3day'))->format(DATE_RFC3339),
             ],
         ]);
-        static::assertInternalType('array', $response);
+        static::assertIsArray($response);
         static::$couponPromotionId = $response['id'];
     }
 
@@ -206,7 +209,7 @@ class PromotionsTest extends AbstractAPITest
             'limit' => 20,
             'offset' => 0,
         ]);
-        static::assertInternalType('array', $response);
+        static::assertIsArray($response);
     }
 
     /**

--- a/tests/Integration/API/ReportsTest.php
+++ b/tests/Integration/API/ReportsTest.php
@@ -15,7 +15,7 @@ class ReportsTest extends AbstractAPITest
             'limit' => 2,
             'offset' => 0,
         ]);
-        static::assertInternalType('array', $response);
+        static::assertIsArray($response);
     }
 
     public function testSearchPaymentsRegistryWithParams()
@@ -27,7 +27,7 @@ class ReportsTest extends AbstractAPITest
             'offset' => 0,
             'status' => 'created',
         ]);
-        static::assertInternalType('array', $response);
+        static::assertIsArray($response);
     }
 
     public function testListPaymentsRegistry()
@@ -42,19 +42,19 @@ class ReportsTest extends AbstractAPITest
             'show_total' => true,
             'status' => 'done',
         ]);
-        static::assertInternalType('array', $response);
+        static::assertIsArray($response);
     }
 
     public function testListTransfersRegistry()
     {
         $response = static::$xsollaClient->ListTransfersRegistry();
-        static::assertInternalType('array', $response);
+        static::assertIsArray($response);
     }
 
     public function testListReportsRegistry()
     {
         $response = static::$xsollaClient->ListReportsRegistry();
-        static::assertInternalType('array', $response);
+        static::assertIsArray($response);
     }
 
     public function testCreateRefundRequest()

--- a/tests/Integration/API/StorefrontTest.php
+++ b/tests/Integration/API/StorefrontTest.php
@@ -20,7 +20,7 @@ class StorefrontTest extends AbstractAPITest
                 'currency' => self::CURRENCY,
             ]
         );
-        static::assertInternalType('array', $response);
+        static::assertIsArray($response);
     }
 
     public function testGetStorefrontVirtualGroups()
@@ -33,7 +33,7 @@ class StorefrontTest extends AbstractAPITest
                 'currency' => self::CURRENCY,
             ]
         );
-        static::assertInternalType('array', $response);
+        static::assertIsArray($response);
     }
 
     public function testGetStorefrontVirtualItems()
@@ -47,7 +47,7 @@ class StorefrontTest extends AbstractAPITest
                 'group_id' => 7,
             ]
         );
-        static::assertInternalType('array', $response);
+        static::assertIsArray($response);
     }
 
     public function testGetStorefrontSubscriptions()
@@ -60,7 +60,7 @@ class StorefrontTest extends AbstractAPITest
                 'currency' => self::CURRENCY,
             ]
         );
-        static::assertInternalType('array', $response);
+        static::assertIsArray($response);
     }
 
     public function testGetStorefrontBonus()
@@ -73,6 +73,6 @@ class StorefrontTest extends AbstractAPITest
                 'currency' => self::CURRENCY,
             ]
         );
-        static::assertInternalType('array', $response);
+        static::assertIsArray($response);
     }
 }

--- a/tests/Integration/API/SubscriptionsTest.php
+++ b/tests/Integration/API/SubscriptionsTest.php
@@ -42,7 +42,7 @@ class SubscriptionsTest extends AbstractAPITest
             'request' => $this->plan,
         ]);
         static::assertArrayHasKey('plan_id', $response);
-        static::assertInternalType('integer', $response['plan_id']);
+        static::assertIsInt($response['plan_id']);
         static::$planId = $response['plan_id'];
     }
 
@@ -55,7 +55,7 @@ class SubscriptionsTest extends AbstractAPITest
             'project_id' => static::$projectId,
             'limit' => 100,
         ]);
-        static::assertInternalType('array', $response);
+        static::assertIsArray($response);
     }
 
     /**
@@ -68,7 +68,7 @@ class SubscriptionsTest extends AbstractAPITest
             'plan_id' => static::$planId,
             'request' => $this->plan,
         ]);
-        static::assertInternalType('array', $response);
+        static::assertIsArray($response);
     }
 
     /**
@@ -133,7 +133,7 @@ class SubscriptionsTest extends AbstractAPITest
             'group_id' => $this->product['group_id'],
             'external_id' => 12345,
         ]);
-        static::assertInternalType('array', $response);
+        static::assertIsArray($response);
     }
 
     /**
@@ -146,7 +146,7 @@ class SubscriptionsTest extends AbstractAPITest
             'product_id' => static::$productId,
             'request' => $this->product,
         ]);
-        static::assertInternalType('array', $response);
+        static::assertIsArray($response);
     }
 
     /**
@@ -166,7 +166,7 @@ class SubscriptionsTest extends AbstractAPITest
         $response = static::$xsollaClient->ListSubscriptionProducts([
             'project_id' => static::$projectId,
         ]);
-        static::assertInternalType('array', $response);
+        static::assertIsArray($response);
     }
 
     public function testListSubscriptionProductsWithParams()
@@ -175,7 +175,7 @@ class SubscriptionsTest extends AbstractAPITest
             'project_id' => static::$projectId,
             'product_id' => static::$productId,
         ]);
-        static::assertInternalType('array', $response);
+        static::assertIsArray($response);
     }
 
     public function testUpdateSubscription()
@@ -189,7 +189,7 @@ class SubscriptionsTest extends AbstractAPITest
             'project_id' => static::$projectId,
             'user_id' => static::$userId,
         ]);
-        static::assertInternalType('array', $response);
+        static::assertIsArray($response);
     }
 
     public function testListSubscriptionWithParams()
@@ -200,7 +200,7 @@ class SubscriptionsTest extends AbstractAPITest
             'plan_id' => static::$planId,
             'product_id' => static::$productId,
         ]);
-        static::assertInternalType('array', $response);
+        static::assertIsArray($response);
     }
 
     public function testListUserSubscriptionPayments()
@@ -209,7 +209,7 @@ class SubscriptionsTest extends AbstractAPITest
             'project_id' => static::$projectId,
             'user_id' => static::$userId,
         ]);
-        static::assertInternalType('array', $response);
+        static::assertIsArray($response);
     }
 
     public function testListSubscriptionPayments()
@@ -217,7 +217,7 @@ class SubscriptionsTest extends AbstractAPITest
         $response = static::$xsollaClient->ListSubscriptionPayments([
             'project_id' => static::$projectId,
         ]);
-        static::assertInternalType('array', $response);
+        static::assertIsArray($response);
     }
 
     public function testListSubscriptionCurrencies()
@@ -225,6 +225,6 @@ class SubscriptionsTest extends AbstractAPITest
         $response = static::$xsollaClient->ListSubscriptionCurrencies([
             'project_id' => static::$projectId,
         ]);
-        static::assertInternalType('array', $response);
+        static::assertIsArray($response);
     }
 }

--- a/tests/Integration/API/SupportTest.php
+++ b/tests/Integration/API/SupportTest.php
@@ -10,7 +10,7 @@ class SupportTest extends AbstractAPITest
     public function testListSupportTickets()
     {
         $response = static::$xsollaClient->ListSupportTickets();
-        static::assertInternalType('array', $response);
+        static::assertIsArray($response);
     }
 
     public function testListSupportTicketsWithParams()
@@ -25,7 +25,7 @@ class SupportTest extends AbstractAPITest
             'limit' => 100,
             'sender' => 'user',
         ]);
-        static::assertInternalType('array', $response);
+        static::assertIsArray($response);
     }
 
     public function testListSupportTicketComments()

--- a/tests/Integration/API/UserAttributesTest.php
+++ b/tests/Integration/API/UserAttributesTest.php
@@ -11,7 +11,7 @@ class UserAttributesTest extends AbstractAPITest
 
     protected $userAttribute;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->userAttribute = [
@@ -42,7 +42,7 @@ class UserAttributesTest extends AbstractAPITest
             'project_id' => static::$projectId,
             'user_attribute_id' => static::$attributeId,
         ]);
-        static::assertInternalType('array', $response);
+        static::assertIsArray($response);
     }
 
     /**
@@ -66,7 +66,7 @@ class UserAttributesTest extends AbstractAPITest
         $response = static::$xsollaClient->ListUserAttributes([
             'project_id' => static::$projectId,
         ]);
-        static::assertInternalType('array', $response);
+        static::assertIsArray($response);
     }
 
     /**

--- a/tests/Integration/API/VirtualCurrencyTest.php
+++ b/tests/Integration/API/VirtualCurrencyTest.php
@@ -29,6 +29,6 @@ class VirtualCurrencyTest extends AbstractAPITest
     public function testGetProjectVirtualCurrencySettings()
     {
         $response = static::$xsollaClient->GetProjectVirtualCurrencySettings(['project_id' => static::$projectId]);
-        static::assertInternalType('array', $response);
+        static::assertIsArray($response);
     }
 }

--- a/tests/Integration/API/VirtualItemsTest.php
+++ b/tests/Integration/API/VirtualItemsTest.php
@@ -25,7 +25,7 @@ class VirtualItemsTest extends AbstractAPITest
         'enabled' => true,
     ];
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         if (!static::$virtualItemSku) {
@@ -39,7 +39,7 @@ class VirtualItemsTest extends AbstractAPITest
         $response = static::$xsollaClient->ListVirtualItemsGroups([
             'project_id' => static::$projectId,
         ]);
-        static::assertInternalType('array', $response);
+        static::assertIsArray($response);
     }
 
     public function testListVirtualItems()
@@ -47,7 +47,7 @@ class VirtualItemsTest extends AbstractAPITest
         $response = static::$xsollaClient->ListVirtualItems([
             'project_id' => static::$projectId,
         ]);
-        static::assertInternalType('array', $response);
+        static::assertIsArray($response);
     }
 
     public function testListVirtualItemsWithParams()
@@ -58,7 +58,7 @@ class VirtualItemsTest extends AbstractAPITest
             'limit' => 100,
             'has_price' => 'virtual_currency',
         ]);
-        static::assertInternalType('array', $response);
+        static::assertIsArray($response);
     }
 
     public function testCreateVirtualItemsGroup()
@@ -81,7 +81,7 @@ class VirtualItemsTest extends AbstractAPITest
             'project_id' => static::$projectId,
             'group_id' => static::$virtualItemsGroupId,
         ]);
-        static::assertInternalType('array', $response);
+        static::assertIsArray($response);
     }
 
     /**
@@ -119,7 +119,7 @@ class VirtualItemsTest extends AbstractAPITest
             'project_id' => static::$projectId,
             'item_id' => static::$virtualItemId,
         ]);
-        static::assertInternalType('array', $response);
+        static::assertIsArray($response);
     }
 
     /**

--- a/tests/Integration/API/WalletTest.php
+++ b/tests/Integration/API/WalletTest.php
@@ -21,7 +21,7 @@ class WalletTest extends AbstractAPITest
             'project_id' => static::$projectId,
             'user_id' => static::$userId,
         ]);
-        static::assertInternalType('array', $response);
+        static::assertIsArray($response);
     }
 
     public function testUpdateWalletUser()
@@ -43,7 +43,7 @@ class WalletTest extends AbstractAPITest
             'limit' => 1,
             'offset' => 0,
         ]);
-        static::assertInternalType('array', $response);
+        static::assertIsArray($response);
     }
 
     public function testListWalletUsersWithParams()
@@ -54,7 +54,7 @@ class WalletTest extends AbstractAPITest
             'offset' => 0,
             'user_requisites' => static::$userId,
         ]);
-        static::assertInternalType('array', $response);
+        static::assertIsArray($response);
     }
 
     public function testListWalletUserOperations()
@@ -65,7 +65,7 @@ class WalletTest extends AbstractAPITest
             'datetime_from' => '2015-01-01T00:00:00Z',
             'datetime_to' => '2016-01-01T00:00:00Z',
         ]);
-        static::assertInternalType('array', $response);
+        static::assertIsArray($response);
     }
 
     public function testListWalletUserOperationsWithParams()
@@ -77,7 +77,7 @@ class WalletTest extends AbstractAPITest
             'datetime_to' => '2016-01-01T00:00:00Z',
             'transaction_type' => 'payment',
         ]);
-        static::assertInternalType('array', $response);
+        static::assertIsArray($response);
     }
 
     public function testRechargeWalletUserBalance()
@@ -131,7 +131,7 @@ class WalletTest extends AbstractAPITest
             'limit' => 1,
             'offset' => 0,
         ]);
-        static::assertInternalType('array', $response);
+        static::assertIsArray($response);
     }
 
     /**

--- a/tests/Integration/Webhook/ServerTest.php
+++ b/tests/Integration/Webhook/ServerTest.php
@@ -29,7 +29,7 @@ class ServerTest extends TestCase
      */
     protected static $httpClient;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         self::setUpPhpServer();
         self::setUpHttpClient();
@@ -37,7 +37,7 @@ class ServerTest extends TestCase
 
     private static function setUpPhpServer()
     {
-        self::$process = new Process('php -S 127.0.0.1:8999', __DIR__ . '/../../Resources/Scripts');
+        self::$process = new Process(['php', '-S', '127.0.0.1:8999'], __DIR__.'/../../Resources/Scripts');
         self::$process->setTimeout(1);
         self::$process->start();
         usleep(100000);
@@ -51,7 +51,7 @@ class ServerTest extends TestCase
         ]);
     }
 
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
         self::$process->stop(0);
     }
@@ -67,11 +67,11 @@ class ServerTest extends TestCase
      */
     public function testResponse($expectedStatusCode, $expectedResponseContent, $request, $testCase, $testHeaders)
     {
-        $signature = sha1($request . self::PROJECT_SECRET_KEY);
-        $headers = $testHeaders ? $testHeaders : ['Authorization' => 'Signature ' . $signature];
+        $signature = sha1($request.self::PROJECT_SECRET_KEY);
+        $headers = $testHeaders ? $testHeaders : ['Authorization' => 'Signature '.$signature];
 
         try {
-            $response = self::$httpClient->post('/webhook_server.php?test_case=' . $testCase,
+            $response = self::$httpClient->post('/webhook_server.php?test_case='.$testCase,
                 ['headers' => $headers, 'body' => $request]);
         } catch (BadResponseException | ClientException $e) {
             $response = $e->getResponse();
@@ -79,12 +79,12 @@ class ServerTest extends TestCase
         static::assertSame($expectedResponseContent, $response->getBody()->getContents());
         static::assertSame($expectedStatusCode, $response->getStatusCode());
         static::assertArrayHasKey('x-xsolla-sdk', $response->getHeaders());
-        static::assertSame(Version::getVersion(), (string)$response->getHeader('x-xsolla-sdk')[0]);
-        static::assertNotNull((string)$response->getHeader('content-type')[0]);
+        static::assertSame(Version::getVersion(), (string) $response->getHeader('x-xsolla-sdk')[0]);
+        static::assertNotNull((string) $response->getHeader('content-type')[0]);
         if (Response::HTTP_NO_CONTENT === $response->getStatusCode()) {
-            static::assertStringStartsWith('text/plain', (string)$response->getHeader('content-type')[0]);
+            static::assertStringStartsWith('text/plain', (string) $response->getHeader('content-type')[0]);
         } else {
-            static::assertStringStartsWith('application/json', (string)$response->getHeader('content-type')[0]);
+            static::assertStringStartsWith('application/json', (string) $response->getHeader('content-type')[0]);
         }
     }
 

--- a/tests/Unit/Webhook/Message/AfsRejectMessageTest.php
+++ b/tests/Unit/Webhook/Message/AfsRejectMessageTest.php
@@ -2,7 +2,6 @@
 
 namespace Xsolla\SDK\Tests\Unit\Webhook\Message;
 
-
 use PHPUnit\Framework\TestCase;
 use Xsolla\SDK\Webhook\Message\AfsRejectMessage;
 
@@ -18,20 +17,19 @@ class AfsRejectMessageTest extends TestCase
             'phone' => '18777976552',
             'email' => 'email@example.com',
             'id' => '1234567',
-            'country' => 'US'
+            'country' => 'US',
          ],
         'transaction' => [
             'id' => 87654321,
             'payment_date' => '2014-09-23T19:25:25+04:00',
             'payment_method' => 1380,
-            'external_id' => 12345678
+            'external_id' => 12345678,
         ],
         'refund_details' => [
             'code' => 4,
-            'reason' => 'Potential fraud'
-        ]
+            'reason' => 'Potential fraud',
+        ],
     ];
-
 
     public function test()
     {
@@ -39,6 +37,5 @@ class AfsRejectMessageTest extends TestCase
         static::assertSame($this->request['transaction']['id'], $message->getPaymentId());
         static::assertSame($this->request['transaction']['external_id'], $message->getExternalPaymentId());
         static::assertSame($this->request['refund_details'], $message->getRefundDetails());
-
     }
 }


### PR DESCRIPTION
Hey there,

René here from OWN3D.TV. We're planning to upgrade to PHP 8 and need to bump some libs to add support.

I would also recommend to set the PHP support to ^ instead of ~. So you don't have to make a new release for every minor php release on the part of Xsolla.

* Changed support version of PHP to ^7.1.3|^8.0
* Changed version of phpunit/phpunit from ~7.3 to ^9.0
* Fixed null-return in AfsRejectMessage::getExternalPaymentId() (Missing 'return' statement)
* Fixed process creation in ServerTest::setUpPhpServer() (expected parameter of type 'array')
* Fixed "Qualifier can be replaced with an import"
* Fixed "Redundant default attribute value assignment" in phpunit.xml.dist

I was not able to run all phpunit tests due the following errors:

```
Component subscriptions is not launched. Please check it here ...
Component virtual_currency is not launched. Please check it here ...
```

Thanks

René