### PR TITLE
FIX: Authorization header case sensitive check

### DIFF
--- a/src/Webhook/WebhookAuthenticator.php
+++ b/src/Webhook/WebhookAuthenticator.php
@@ -67,6 +67,9 @@ class WebhookAuthenticator
     public function authenticateSignature(WebhookRequest $webhookRequest)
     {
         $headers = $webhookRequest->getHeaders();
+        if(isset($headers["Authorization"])){
+            $headers["authorization"]=$headers["Authorization"];
+        }
         if (!array_key_exists('authorization', $headers)) {
             throw new InvalidSignatureException('"Authorization" header not found in Xsolla webhook request. Please check troubleshooting section in README.md https://github.com/xsolla/xsolla-sdk-php#troubleshooting');
         }


### PR DESCRIPTION
 Closes #98 
 
 Adds a copy of authorization key to pass case sensitive check 
 ```
if(isset($headers["Authorization"])){
    $headers["authorization"]=$headers["Authorization"];
}
if (!array_key_exists('authorization', $headers)) {
            throw new InvalidSignatureException('"Authorization" header not found in Xsolla webhook request. Please check troubleshooting section in README.md https://github.com/xsolla/xsolla-sdk-php#troubleshooting');
}
```

